### PR TITLE
[FEAT] translate chat & stt in live #89

### DIFF
--- a/app/core/time.py
+++ b/app/core/time.py
@@ -1,0 +1,12 @@
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+JST = timezone(timedelta(hours=9))
+
+
+def to_jst_iso(value: Optional[datetime]) -> Optional[str]:
+    if not value:
+        return None
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.astimezone(JST).isoformat()

--- a/app/meeting/live_history.py
+++ b/app/meeting/live_history.py
@@ -86,6 +86,8 @@ async def get_session_messages(
                 "display_name": sender_name,
                 "text": msg.text,
                 "lang": msg.lang,
+                "translated_text": msg.translated_text,
+                "translated_lang": msg.translated_lang,
                 "created_at": msg.created_at
             })
 

--- a/app/meeting/stt_events.py
+++ b/app/meeting/stt_events.py
@@ -1,0 +1,64 @@
+import asyncio
+import json
+import os
+
+from redis import asyncio as aioredis
+
+from app.core.config import settings
+from app.core.logging import get_logger
+from app.meeting.ws.manager import manager
+
+logger = get_logger(__name__)
+
+ALIEN_STAMP = "👽" * 20
+STT_EVENTS_CHANNEL = os.getenv("LIVEKIT_STT_EVENTS_CHANNEL", "livekit:stt")
+
+
+async def start_stt_event_listener() -> None:
+    if not settings.enable_websocket:
+        return
+
+    redis = aioredis.from_url(
+        settings.redis_url,
+        db=settings.redis_db,
+        encoding="utf-8",
+        decode_responses=True,
+    )
+    pubsub = redis.pubsub()
+    await pubsub.subscribe(STT_EVENTS_CHANNEL)
+    logger.info(f"{ALIEN_STAMP} [STT WS] subscribed channel={STT_EVENTS_CHANNEL}")
+
+    try:
+        async for message in pubsub.listen():
+            if message.get("type") != "message":
+                await asyncio.sleep(0)
+                continue
+            raw = message.get("data")
+            if not raw:
+                continue
+            try:
+                payload = json.loads(raw)
+            except json.JSONDecodeError:
+                continue
+
+            room_id = payload.get("room_id")
+            ws_message = payload.get("message")
+            if not room_id or not ws_message:
+                continue
+
+            await manager.broadcast(room_id, ws_message)
+
+            data = ws_message.get("data") or {}
+            logger.info(
+                f"{ALIEN_STAMP} [STT WS] sent "
+                f"room_id={room_id} seq={data.get('seq')} "
+                f"text={data.get('text')!r} translated={data.get('translated_text')!r}"
+            )
+    except asyncio.CancelledError:
+        pass
+    finally:
+        try:
+            await pubsub.unsubscribe(STT_EVENTS_CHANNEL)
+            await pubsub.close()
+        finally:
+            await redis.close()

--- a/app/meeting/ws/manager.py
+++ b/app/meeting/ws/manager.py
@@ -49,7 +49,12 @@ class ConnectionManager:
     async def broadcast(self, room_id: str, message: dict):
         if room_id in self.active_rooms:
             count = len(self.active_rooms[room_id])
-            logger.debug(f"WS Broadcast | Room: {room_id} | Targets: {count} | MsgType: {message.get('type')}")
+            try:
+                import json
+                payload = json.dumps(message, ensure_ascii=False, default=str)
+            except Exception:
+                payload = str(message)
+            logger.info(f"🩵🩵🩵🩵🩵🩵 WS Broadcast | Room: {room_id} | Targets: {count} | Payload: {payload}")
             for connection in self.active_rooms[room_id]:
                 try:
                     await connection.send_json(message)

--- a/app/meeting/ws/ws_message.py
+++ b/app/meeting/ws/ws_message.py
@@ -11,6 +11,7 @@ from app.meeting.ws.manager import manager
 from app.translation.deepl_service import deepl_service
 from app.translation.openai_service import openai_service
 from app.core.logging import get_logger
+from app.core.time import to_jst_iso
 
 logger = get_logger(__name__)
 
@@ -27,7 +28,7 @@ def _ai_event_payload(ai_event: AIEvent) -> dict:
         "text": ai_event.text,
         "lang": ai_event.lang,
         "meta": ai_event.meta,
-        "created_at": ai_event.created_at.isoformat() if ai_event.created_at else None,
+        "created_at": to_jst_iso(ai_event.created_at),
     }
 
 def _normalize_lang(lang: Optional[str]) -> str:
@@ -203,7 +204,7 @@ async def handle_chat_message(room_id: str, user_id: str, data: dict):
                 "lang": new_message.lang,
                 "translated_text": new_message.translated_text,
                 "translated_lang": new_message.translated_lang,
-                "created_at": new_message.created_at.isoformat()
+                "created_at": to_jst_iso(new_message.created_at),
             }
         }
         await manager.broadcast(room_id, broadcast_data)
@@ -300,7 +301,7 @@ async def handle_stt_message(session_id: str, user_id: str, data: dict):
                 "text": new_message.text,
                 "lang": new_message.lang,
                 "is_final": True,
-                "created_at": new_message.created_at.isoformat()
+                "created_at": to_jst_iso(new_message.created_at),
             }
         }
         await manager.broadcast(session_id, broadcast_data)

--- a/app/models/message.py
+++ b/app/models/message.py
@@ -25,6 +25,8 @@ class ChatMessage(Base):
     
     text: Mapped[str] = mapped_column(Text, nullable=False)
     lang: Mapped[Optional[str]] = mapped_column(String(8), nullable=True)
+    translated_text: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    translated_lang: Mapped[Optional[str]] = mapped_column(String(8), nullable=True)
     start_ms: Mapped[Optional[int]] = mapped_column(nullable=True)
     end_ms: Mapped[Optional[int]] = mapped_column(nullable=True)
     meta: Mapped[Optional[dict]] = mapped_column(JSON, nullable=True)

--- a/app/translation/openai_service.py
+++ b/app/translation/openai_service.py
@@ -1,4 +1,5 @@
 from typing import List, Dict
+import json
 import openai
 from app.core.config import settings
 from app.core.logging import get_logger
@@ -51,5 +52,49 @@ class OpenAIService:
         except Exception as e:
             logger.error(f"OpenAI API call failed: {e}")
             return []
+
+    async def translate_text(self, text: str, source_lang: str, target_lang: str) -> str:
+        """
+        Translate text using OpenAI.
+        Returns translated text only.
+        """
+        if not text:
+            return ""
+
+        if not self.client or settings.use_mock_translation:
+            logger.warning("OpenAI API key is not configured. Returning mock translation.")
+            return self._mock_translate(text, target_lang)
+
+        prompt = (
+            "Translate the following text from {source_lang} to {target_lang}. "
+            "Return a JSON object with a single key \"translation\" and no other text.\n\n"
+            "Text:\n"
+            "\"\"\"{text}\"\"\""
+        ).format(source_lang=source_lang, target_lang=target_lang, text=text)
+
+        try:
+            response = self.client.chat.completions.create(
+                model=self.model,
+                messages=[
+                    {"role": "system", "content": "You are a precise translation engine."},
+                    {"role": "user", "content": prompt}
+                ],
+                response_format={"type": "json_object"},
+                temperature=0
+            )
+
+            result = json.loads(response.choices[0].message.content)
+            if isinstance(result, dict) and "translation" in result:
+                return str(result["translation"])
+            if isinstance(result, str):
+                return result
+            return response.choices[0].message.content.strip()
+        except Exception as e:
+            logger.error(f"OpenAI translation failed: {e}")
+            return self._mock_translate(text, target_lang)
+
+    def _mock_translate(self, text: str, target_lang: str) -> str:
+        prefix = f"[{target_lang}]" if target_lang else "[TRANS]"
+        return f"{prefix} {text}"
 
 openai_service = OpenAIService()

--- a/app/translation/openai_service.py
+++ b/app/translation/openai_service.py
@@ -61,7 +61,7 @@ class OpenAIService:
         if not text:
             return ""
 
-        if not self.client or settings.use_mock_translation:
+        if not self.client:
             logger.warning("OpenAI API key is not configured. Returning mock translation.")
             return self._mock_translate(text, target_lang)
 

--- a/migrations/versions/008_add_chat_msg_trans_cols.py
+++ b/migrations/versions/008_add_chat_msg_trans_cols.py
@@ -1,0 +1,40 @@
+"""add translation columns to chat_messages
+
+Revision ID: 008_add_chat_msg_trans_cols
+Revises: 007_add_stt_ai_tables
+Create Date: 2026-01-30 12:10:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "008_add_chat_msg_trans_cols"
+down_revision: Union[str, None] = "007_add_stt_ai_tables"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    existing_cols = {col["name"] for col in inspector.get_columns("chat_messages")}
+
+    if "translated_text" not in existing_cols:
+        op.add_column("chat_messages", sa.Column("translated_text", sa.Text(), nullable=True))
+    if "translated_lang" not in existing_cols:
+        op.add_column("chat_messages", sa.Column("translated_lang", sa.String(length=8), nullable=True))
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    existing_cols = {col["name"] for col in inspector.get_columns("chat_messages")}
+
+    if "translated_lang" in existing_cols:
+        op.drop_column("chat_messages", "translated_lang")
+    if "translated_text" in existing_cols:
+        op.drop_column("chat_messages", "translated_text")

--- a/workers/realtime_agent.py
+++ b/workers/realtime_agent.py
@@ -19,6 +19,7 @@ from redis import asyncio as aioredis
 from sqlalchemy import func, select
 from sqlalchemy.exc import IntegrityError
 
+from app.core.time import to_jst_iso
 from app.infra.db import AsyncSessionLocal
 from app.models.room import RoomMember, RoomLiveSession
 from app.models.stt import RoomAiResponse, RoomSttResult
@@ -913,7 +914,7 @@ class RealtimeSession:
                                     "translated_text": translated_text,
                                     "translated_lang": translated_lang,
                                     "is_final": True,
-                                    "created_at": datetime.utcnow().isoformat(),
+                                    "created_at": to_jst_iso(datetime.utcnow()),
                                 },
                             },
                         )


### PR DESCRIPTION
## 📌 What did you do?

* Added **translation-aware websocket payloads** for chat/STT messages and introduced a **Redis-subscribed STT event broadcaster** for realtime delivery

---

## 🔧 How did you do it?

* Added DB migration + model fields for `translated_text` / `translated_lang` on `chat_messages`
* Implemented translation flow with **DeepL first, then OpenAI fallback**, and broadcasted a **combined payload (original + translation)** over websocket
* Introduced a Redis pubsub listener (`livekit:stt`) and wired it into FastAPI lifespan as a background task with proper shutdown handling

